### PR TITLE
Three quick fixes on the '<HelloWorld /> should render an ul with 3 i…

### DIFF
--- a/src/webparts/helloWorld/components/HelloWorld.tsx
+++ b/src/webparts/helloWorld/components/HelloWorld.tsx
@@ -24,16 +24,15 @@ export default class HelloWorld extends React.Component<IHelloWorldProps, IHello
     }
 
     private _renderListAsync(): void {
-        // Local environment
-        if (Environment.type === EnvironmentType.Local) {
+        if (Environment.type == EnvironmentType.SharePoint || Environment.type == EnvironmentType.ClassicSharePoint) {
+            // Not implemented ...
+        } else {
+            // Local, other environment
             this._getMockListData().then((response) => {
                 this.setState({
                     results: response
                 });
             });
-        }
-        else if (Environment.type == EnvironmentType.SharePoint || Environment.type == EnvironmentType.ClassicSharePoint) {
-            // Not implemented ...
         }
     }
 

--- a/src/webparts/helloWorld/tests/HelloWorld.test.tsx
+++ b/src/webparts/helloWorld/tests/HelloWorld.test.tsx
@@ -48,11 +48,19 @@ describe('<HelloWorld />', () => {
         expect(componentDidMountSpy.calledOnce).to.equal(true);
     });
 
-    it('<HelloWorld /> should render an ul with 3 items (using the mock data)', () => {
-        // Wait for 2 seconds to check if your mock results are retrieved
+    it('<HelloWorld /> should render an ul with 3 items (using the mock data)', (done) => {
+        
+        // New instance should be created for this test due to setTimeout
+        // If the global renderedElement used, the result of "ul li"" will be 10 instead of 3
+        // because the state changes to 10 in the last test and 
+        // the last test is executed before this one bacause of setTimeout
+        let renderedElement1 = mount(<HelloWorld description={descTxt} />);
+
+        // Wait for 1 second to check if your mock results are retrieved
         setTimeout(() => {
-            expect(renderedElement.state('results')).to.not.be.null;
-            expect(renderedElement.find('ul li').length).to.be.equal(3);
+            expect(renderedElement1.state('results')).to.not.be.null;
+            expect(renderedElement1.find('ul li').length).to.be.equal(3);
+            done();  // done is required by mocha, otherwise the test will yield SUCCESS no matter of the expect cases
         }, 1000);
     });
 


### PR DESCRIPTION
Three quick fixes on the '<HelloWorld /> should render an ul with 3 items (using the mock data)' test to get it work.

- Added done() at the end of the setTimeout. If done() not present, the test will yield SUCCESS no matter of the expect cases because it does not wait the 'expects' in the setTimeout function
- New HelloWorld mock instance created in the test because after 1 sec the global renderedElement setState has been changed by the latest test to 10 elements instead of 3 (because of setTimeout  this test is pushed at the end of the event loop and the last one is executed before this one)
- The Environment.type === EnvironmentType.Local dependency removed from the _renderListAsync method because I could no find a way to fake it /stub it due its readonly nature so the mocked object is not aware of the environment (Environment.type = undefined when the test is run)

FYI:
This is a good article on mocha and async tests - http://staxmanade.com/2015/11/testing-asyncronous-code-with-mochajs-and-es7-async-await/
I will prepare some videos on debugging SFPx react tests soon.