### PR TITLE
VCode IntelliSense support for sinon added.

### DIFF
--- a/src/webparts/helloWorld/tests/HelloWorld.test.tsx
+++ b/src/webparts/helloWorld/tests/HelloWorld.test.tsx
@@ -6,11 +6,11 @@ import { assert, expect } from 'chai';
 import { mount } from 'enzyme';
 import HelloWorld from '../components/HelloWorld';
 
-declare const sinon;
+declare const sinon: sinon.SinonStatic;
 
 describe('<HelloWorld />', () => {
     const descTxt = "TestingThisOneOut";
-    let componentDidMountSpy;
+    let componentDidMountSpy: sinon.SinonSpy;
     let renderedElement;
 
     before(() => {


### PR DESCRIPTION
I am seeing `/// <reference types="sinon" />` at the top so we can make some use of it by assigning sinon types at line 9 and 13. This will allow us to use IntelliSense `.` key magic. Long live the IntelliSense  `.` :)

FYI: adding `@types/enzyme` to the packages.json and  `/// <reference types="enzyme" />` here would bring more VCode IntelliSense magic.